### PR TITLE
Fix const-prop/const-fold cross references

### DIFF
--- a/fat_python.rst
+++ b/fat_python.rst
@@ -257,8 +257,7 @@ Propagate constant values of variables.
 |       return y |       return 1       |
 +----------------+----------------------+
 
-See also the :ref:`constant propagation <const-prop>` optimization.
-
+See also the :ref:`constant folding <const-fold>` optimization.
 
 .. _fat-const-fold:
 
@@ -284,8 +283,7 @@ Example:
 |       return 1 + 1 |       return 2   |
 +--------------------+------------------+
 
-See also the :ref:`constant folding <const-fold>` optimization.
-
+See also the :ref:`constant propagation <const-prop>` optimization.
 
 .. _fat-copy-builtin-to-constant:
 


### PR DESCRIPTION
The "Constant Propagation" and "Constant Folding" sections each contain links to themselves; presumably they're meant to link to each other?  Fixed in the following, I believe (though I messed up the whitespace slightly and github won't let me edit this anymore)