### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Notes on making CPython faster
 
-* Read online: https://faster-cpython.readthedocs.org/
+* Read online: https://faster-cpython.readthedocs.io/
 * Compile to HTML: make html
 * Documentation built by Sphinx
 

--- a/ast_optimizer.rst
+++ b/ast_optimizer.rst
@@ -22,7 +22,7 @@ See :ref:`old AST optimizer <old-ast-optimizer>`.
 fatoptimizer
 ============
 
-`fatoptimizer project <https://fatoptimizer.readthedocs.org/en/latest/>`_: AST
+`fatoptimizer project <https://fatoptimizer.readthedocs.io/en/latest/>`_: AST
 optimizer implementing multiple optimizations and can specialize functions
 using guards of the ``fat`` module.
 

--- a/bytecode.rst
+++ b/bytecode.rst
@@ -45,7 +45,7 @@ Should be rewritten as an :ref:`AST optimizer <ast-optimizers>`.
 Bytecode
 ========
 
-* `bytecode <https://bytecode.readthedocs.org/>`_
+* `bytecode <https://bytecode.readthedocs.io/>`_
 * `byteplay <https://github.com/serprex/byteplay>`_:
   `byteplay documentation <https://wiki.python.org/moin/ByteplayDoc>`_
   (see also the `old byteplay hosted on Google Code

--- a/fat_python.rst
+++ b/fat_python.rst
@@ -35,15 +35,15 @@ it will use two versions of some functions where one version is specialised to
 specific argument types, a specific environment, optimized when builtins are
 not mocked, etc.
 
-See the `fatoptimizer documentation <https://fatoptimizer.readthedocs.org/>`_
+See the `fatoptimizer documentation <https://fatoptimizer.readthedocs.io/>`_
 which is the main part of FAT Python.
 
 The FAT Python project is made of multiple parts:
 
-* The `fatoptimizer project <https://fatoptimizer.readthedocs.org/>`_ is the
+* The `fatoptimizer project <https://fatoptimizer.readthedocs.io/>`_ is the
   static optimizer for Python 3.6 using function specialization with guards. It
   is implemented as an AST optimizer.
-* The `fat module <https://fatoptimizer.readthedocs.org/en/latest/fat.html>`_
+* The `fat module <https://fatoptimizer.readthedocs.io/en/latest/fat.html>`_
   is a Python extension module (written in C) implementing fast guards. The
   ``fatoptimizer`` optimizer uses ``fat`` guards to specialize functions.
   ``fat`` guards are used to verify assumptions used to specialize the code. If
@@ -144,9 +144,9 @@ You must get ``fat-opt`` (and not ``opt``).
 How can you contribute?
 =======================
 
-The `fatoptimizer project <https://fatoptimizer.readthedocs.org/>`_ needs the
+The `fatoptimizer project <https://fatoptimizer.readthedocs.io/>`_ needs the
 most love. Currently, the optimizer is not really smart. There is a long `TODO
-list <https://fatoptimizer.readthedocs.org/en/latest/todo.html>`_. Pick a
+list <https://fatoptimizer.readthedocs.io/en/latest/todo.html>`_. Pick a
 simple optimization, try to implement it, send a pull request on GitHub. At
 least, any kind of feedback is useful ;-)
 

--- a/optimizations.rst
+++ b/optimizations.rst
@@ -3,7 +3,7 @@ Optimizations
 *************
 
 See also `fatoptimizer optimizations
-<https://fatoptimizer.readthedocs.org/en/latest/optimizations.html>`_.
+<https://fatoptimizer.readthedocs.io/en/latest/optimizations.html>`_.
 
 Inline function calls
 =====================

--- a/readonly.rst
+++ b/readonly.rst
@@ -35,7 +35,7 @@ modification, a callback is called with the object and the modified attribute.
 
 This machinery should help static optimizers. See this article for more
 information:
-http://haypo-notes.readthedocs.org/faster_cpython.html
+https://haypo-notes.readthedocs.io/faster_cpython.html
 
 Examples of such optimizers:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.